### PR TITLE
Read through parts of the docs once

### DIFF
--- a/docs/source/orthogonal_sampling.rst
+++ b/docs/source/orthogonal_sampling.rst
@@ -71,7 +71,7 @@ Following, we initiate an :class:`.OrthogonalSamplingDesigner`
 with the parameter. :code:`inter_bin_randomness=0.`. This controls the randomness of the placement of samples within the
 bins. A value of 0.0 places the samples exactly in the middle of the bins, whereas a value of 0.8 (default) would lead to
 placing samples anywhere between :math:`[-0.4 \delta, 0.4 \delta]` within the bin, where :math:`\delta` is the bin size,
-here :math:`\delta=1/8=0.125`. Finally, we generate a doe using only 1 step, i.e. skipping any optimization for now, that we
+here :math:`\delta=1/8=0.125`. Finally, we generate a |DoE| using only 1 step, i.e. skipping any optimization for now, that we
 would do normally and plot the result.
 
 Final step is not mandatory, but it improves the |DoE| quality a lot, as proposed by `Joseph et al. (2008) <https://www3.stat.sinica.edu.tw/statistica/oldpdf/A18n17.pdf>`_:

--- a/docs/source/orthogonal_sampling.rst
+++ b/docs/source/orthogonal_sampling.rst
@@ -46,7 +46,7 @@ We can visualize this as follows:
 .. image:: images/os_lhs_grid.png
     :align: center
 
-Next, we place each sample such that each bin is occupied only ones in each direction. This is quite easy to implement,
+Next, we place each sample such that each bin is occupied only once in each direction. This is quite easy to implement,
 but since we are show casing the capabilities of :code:`experiment-design`, let's use it here.
 
 .. code:: python

--- a/docs/source/orthogonal_sampling.rst
+++ b/docs/source/orthogonal_sampling.rst
@@ -71,7 +71,7 @@ Following, we initiate an :class:`.OrthogonalSamplingDesigner`
 with the parameter. :code:`inter_bin_randomness=0.`. This controls the randomness of the placement of samples within the
 bins. A value of 0.0 places the samples exactly in the middle of the bins, whereas a value of 0.8 (default) would lead to
 placing samples anywhere between :math:`[-0.4 \delta, 0.4 \delta]` within the bin, where :math:`\delta` is the bin size,
-here :math:`1/8=0.125`. Finally, we generate a doe using only 1 step, i.e. skipping any optimization for now, that we
+here :math:`\delta=1/8=0.125`. Finally, we generate a doe using only 1 step, i.e. skipping any optimization for now, that we
 would do normally and plot the result.
 
 Final step is not mandatory, but it improves the |DoE| quality a lot, as proposed by `Joseph et al. (2008) <https://www3.stat.sinica.edu.tw/statistica/oldpdf/A18n17.pdf>`_:

--- a/docs/source/orthogonal_sampling.rst
+++ b/docs/source/orthogonal_sampling.rst
@@ -62,7 +62,7 @@ but since we are show casing the capabilities of :code:`experiment-design`, let'
 .. image:: images/os_lhs_init.png
     :align: center
 
-There are a few important details in the abov.. code so let's walk line by line. After importing the necessary modules,
+There are a few important details in the above code so let's walk line by line. After importing the necessary modules,
 we first set a random seed. This is important for reproducibility. Given the same inputs and seed, we will always
 generate the same design on the same machine. Next, we define a two dimensional parameter space (:class:`.ParameterSpace`)
 within the bounds :math:`[0, 1]^2`. In general, bounds need not be equal. They can be any finite values, provided the lower

--- a/docs/source/orthogonal_sampling.rst
+++ b/docs/source/orthogonal_sampling.rst
@@ -301,7 +301,7 @@ in higher dimensions. Analytically, we know that :math:`\mu_Y = 2d`, where :math
     :align: center
 
 .. warning::
-    Note that th.. code above may take a long time to run. The reason behind this is the number of optimization steps
+    Note that the code above may take a long time to run. The reason behind this is the number of optimization steps
     taken by :class:`.OrthogonalSamplingDesigner` especially in lower sample setting (:math:`\leq 128`) as the optimization has a
     high impact on the quality of the resulting |DoE|. You can choose a smaller :code:`step` value
     (the default is 20000 for :code:`sample_size` :math:`\leq 128` and `2000` otherwise) or even set it to 1 or less to avoid

--- a/docs/source/orthogonal_sampling.rst
+++ b/docs/source/orthogonal_sampling.rst
@@ -54,8 +54,8 @@ but since we are show casing the capabilities of :code:`experiment-design`, let'
     from experiment_design import create_continuous_uniform_space, OrthogonalSamplingDesigner
 
     np.random.seed(1337)
-    space = create_continuous_uniform_space([0., 0], [1., 1.])
-    designer = OrthogonalSamplingDesigner(inter_bin_randomness=0.)
+    space = create_continuous_uniform_space([0.0, 0.0], [1., 1.])
+    designer = OrthogonalSamplingDesigner(inter_bin_randomness=0.0)
     doe = designer.design(space, sample_size=8, steps=1)
     plt.scatter(doe[:, 0], doe[:, 1], label="Init. design")
 
@@ -69,7 +69,7 @@ within the bounds :math:`[0, 1]^2`. In general, bounds need not be equal. They c
 bound for a variable is smaller than its corresponding upper bound.
 Following, we initiate an :class:`.OrthogonalSamplingDesigner`
 with the parameter. :code:`inter_bin_randomness=0.`. This controls the randomness of the placement of samples within the
-bins. A value of 0. places the samples exactly in the middle of the bins, whereas a value of 0.8 (default) would lead to
+bins. A value of 0.0 places the samples exactly in the middle of the bins, whereas a value of 0.8 (default) would lead to
 placing samples anywhere between :math:`[-0.4 \delta, 0.4 \delta]` within the bin, where :math:`\delta` is the bin size,
 here :math:`1/8=0.125`. Finally, we generate a doe using only 1 step, i.e. skipping any optimization for now, that we
 would do normally and plot the result.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -22,7 +22,7 @@ Create and extend experiment designs
 Let's first create a Latin hypercube sampling (|LHS|). We will discuss later why it is superior to random sampling
 (:doc:`Learn more about |LHS| and orthogonal sampling here  <orthogonal_sampling>`). We will first define
 a :class:`.ParameterSpace` with uniform distribution using the function :code:`create_continuous_uniform_space` and
-then use the :class:`.OrthogonalSamplingDesigner` class to generate the |DoE| and plot the result.
+then use the :class:`.OrthogonalSamplingDesigner` class to generate the Design of Experiments (|DoE|) and plot the result.
 
 .. code:: python
 


### PR DESCRIPTION
Hey @canbooo  I just had a nice read through your docs. I think I found some typos and introduced terms.

There are two other points I'd like to mention:

1. In your docstrings you typically capitalize after the colon defining the parameters, but sometimes you deviate from that. For example `:param sample_size: the number of points to be created.` in your `sample_from`function
2. You state that: `Next, we place each sample such that each bin is occupied only ones in each direction.` when you introduce orthogonal sampling. However, the bin is a square and the square is only occupied once. It feels that, in the absence of a good term for higher dimensions, you want to say that for each row and for each column there is exactly one bin occupied. Do I get this right? Maybe one could use the term (hyper) strips, i.e. the union of the cubes along one direction.